### PR TITLE
Implement client-side TLS certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ MANIFEST
 dist/
 salt_pepper.egg-info/
 .tox/
+.eggs/

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Installation
 Usage
 -----
 
-Basic usage is in heavy flux. You can run pepper using the script in %PYTHONHOME%/scripts/pepper (a pepper.cmd wrapper is provided for convenience to Windows users).
+You can run pepper using the script in %PYTHONHOME%/scripts/pepper (a pepper.cmd wrapper is provided for convenience to Windows users).
 
 .. code-block:: bash
 
@@ -69,6 +69,11 @@ or in a configuration file ``$HOME/.pepperrc`` with the following syntax :
   SALTAPI_USER=saltdev
   SALTAPI_PASS=saltdev
   SALTAPI_EAUTH=pam
+
+  # if you use client-side TLS certificates
+  SALTAPI_CA_BUNDLE=/path/to/ca-chain.cert.pem
+  SALTAPI_CLIENT_CERT=/path/to/client.cert.pem
+  SALTAPI_CLIENT_CERT_KEY=/path/to/client.key.pem
 
 Contributing
 ------------


### PR DESCRIPTION
This adds the ability to use client-side TLS certificates when connecting to the salt-api server. Users can specify the required files at either the command line, environment variables, or the `.pepperrc`.