### PR TITLE
Migrate away from pkg_resources

### DIFF
--- a/pepper/__init__.py
+++ b/pepper/__init__.py
@@ -1,15 +1,15 @@
 '''
 Pepper is a CLI front-end to salt-api
 '''
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 from pepper.libpepper import Pepper, PepperException
 
 __all__ = ('__version__', 'Pepper', 'PepperException')
 
 try:
-    __version__ = pkg_resources.get_distribution('salt_pepper').version
-except pkg_resources.DistributionNotFound:
+    __version__ = version('salt_pepper')
+except PackageNotFoundError:
     # package is not installed
     __version__ = None
 


### PR DESCRIPTION
Using pkg_resources as an API is deprecated.
Migrate functionality to the importlib equivalent.

This repairs "No module named 'pkg_resources'" on modern distributions.