### PR TITLE
Implement client-side TLS certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ MANIFEST
 dist/
 salt_pepper.egg-info/
 .tox/
+.eggs/

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Installation
 Usage
 -----
 
-Basic usage is in heavy flux. You can run pepper using the script in %PYTHONHOME%/scripts/pepper (a pepper.cmd wrapper is provided for convenience to Windows users).
+You can run pepper using the script in %PYTHONHOME%/scripts/pepper (a pepper.cmd wrapper is provided for convenience to Windows users).
 
 .. code-block:: bash
 
@@ -69,6 +69,11 @@ or in a configuration file ``$HOME/.pepperrc`` with the following syntax :
   SALTAPI_USER=saltdev
   SALTAPI_PASS=saltdev
   SALTAPI_EAUTH=pam
+
+  # if you use client-side TLS certificates
+  SALTAPI_CA_BUNDLE=/path/to/ca-chain.cert.pem
+  SALTAPI_CLIENT_CERT=/path/to/client.cert.pem
+  SALTAPI_CLIENT_CERT_KEY=/path/to/client.key.pem
 
 Contributing
 ------------

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -1,36 +1,44 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
 import json
 import sys
+
+# Import Testing Libraries
+from mock import MagicMock, mock_open, patch
 
 # Import Pepper Libraries
 import pepper.cli
 
-# Import Testing Libraries
-from mock import patch, mock_open, MagicMock
-
 
 def test_token():
-    sys.argv = ['pepper', '*', 'test.ping']
+    sys.argv = ["pepper", "*", "test.ping"]
     client = pepper.cli.PepperCli()
     client.options.mktoken = True
-    mock_data = (
-        '{"perms": [".*", "@runner", "@wheel", "@jobs"], "start": 1529967752.516165, '
-        '"token": "7130faa1e17f935d5f2702465cafdc73212d64d0", "expire": 1529968905.1131861, '
-        '"user": "pepper", "eauth": "pam"}\n'
-    )
+    mock_data = {
+        "perms": [".*", "@runner", "@wheel", "@jobs"],
+        "start": 1529967752.516165,
+        "token": "7130faa1e17f935d5f2702465cafdc73212d64d0",
+        "expire": 1529968905.1131861,
+        "user": "pepper",
+        "eauth": "pam",
+    }
+    mock_data_json = json.dumps(mock_data)
+
     mock_api = MagicMock()
-    mock_api.login = MagicMock(return_value=mock_data)
-    with patch('pepper.cli.open', mock_open(read_data=mock_data)), \
-            patch('pepper.cli.PepperCli.get_login_details', MagicMock(return_value=mock_data)), \
-            patch('pepper.cli.PepperCli.parse_login', MagicMock(return_value={})), \
-            patch('os.remove', MagicMock(return_value=None)), \
-            patch('json.dump', MagicMock(side_effect=Exception('Test Error'))):
-        ret1 = client.login(mock_api)
-        with patch('os.path.isfile', MagicMock(return_value=False)):
-            ret2 = client.login(mock_api)
-        with patch('time.time', MagicMock(return_value=1529968044.133632)):
-            ret3 = client.login(mock_api)
-    assert json.loads(ret1) == json.loads(mock_data)
-    assert json.loads(ret2) == json.loads(mock_data)
-    assert ret3 == json.loads(mock_data)
+    mock_api.login = MagicMock(return_value=mock_data_json)
+
+    with patch("pepper.cli.open", mock_open(read_data=mock_data_json)), patch(
+        "pepper.cli.PepperCli.get_login_details", MagicMock(return_value=mock_data)
+    ), patch("os.remove", MagicMock(return_value=None)), patch(
+        "json.dump", MagicMock(side_effect=Exception("Test Error"))
+    ):
+        ret1 = client.login(mock_api, mock_data)
+        with patch("os.path.isfile", MagicMock(return_value=False)):
+            ret2 = client.login(mock_api, mock_data)
+        with patch("time.time", MagicMock(return_value=1529968044.133632)):
+            ret3 = client.login(mock_api, mock_data)
+
+    assert json.loads(ret1) == mock_data
+    assert json.loads(ret2) == mock_data
+    assert ret3 == mock_data


### PR DESCRIPTION
This adds the ability to use client-side TLS certificates when connecting to the salt-api server. Users can specify the required files at either the command line, environment variables, or the `.pepperrc`.